### PR TITLE
Switch to go v1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: go
 
 go:
-- 1.9
+- "1.10"
 - tip
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ curl -Ss https://api.radarrelay.com/0x/v0/order/0x10d750751d98bc8a9c29542118fbcf
 
 ### Requirements
 
-* Go 1.9 (It calculate a different hash with 1.10)
+* Go 1.10
 * Ethereum 1.8

--- a/relayer/client_test.go
+++ b/relayer/client_test.go
@@ -221,7 +221,7 @@ func (suite *ClientSuite) TestGetOrdersWithMalformedJSON() {
 	suite.Contains(err.Error(), "error parsing json response")
 }
 
-func (suite *ClientSuite) TestGetTOrdersWithContext() {
+func (suite *ClientSuite) TestGetOrdersWithContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 


### PR DESCRIPTION
`common.HexToHash()` returns something different when not passed a valid Ethereum address on 1.10. Let's ignore issues with wrong input for now and switch to 1.10.