### PR TITLE
Add command to list a relayer's orders

### DIFF
--- a/cmd/orders.go
+++ b/cmd/orders.go
@@ -5,11 +5,27 @@ import (
 )
 
 var (
+	exchangeContractAddress string
+	makerTokenAddress       string
+	takerTokenAddress       string
+	maker                   string
+	taker                   string
+	feeRecipient            string
+)
+
+var (
 	ordersCmd = &cobra.Command{
 		Use: "orders",
 	}
 )
 
 func init() {
+	ordersCmd.PersistentFlags().StringVar(&exchangeContractAddress, "exchange-contract-address", "", "")
+	ordersCmd.PersistentFlags().StringVar(&maker, "maker", "", "")
+	ordersCmd.PersistentFlags().StringVar(&taker, "taker", "", "")
+	ordersCmd.PersistentFlags().StringVar(&makerTokenAddress, "maker-token-address", "", "")
+	ordersCmd.PersistentFlags().StringVar(&takerTokenAddress, "taker-token-address", "", "")
+	ordersCmd.PersistentFlags().StringVar(&feeRecipient, "fee-recipient", "", "")
+
 	rootCmd.AddCommand(ordersCmd)
 }

--- a/cmd/orders_hash.go
+++ b/cmd/orders_hash.go
@@ -13,12 +13,6 @@ import (
 )
 
 var (
-	exchangeContractAddress    string
-	makerTokenAddress          string
-	takerTokenAddress          string
-	maker                      string
-	taker                      string
-	feeRecipient               string
 	makerTokenAmount           string
 	takerTokenAmount           string
 	makerFee                   string
@@ -35,12 +29,6 @@ var (
 )
 
 func init() {
-	ordersHashCmd.Flags().StringVar(&exchangeContractAddress, "exchange-contract-address", "", "")
-	ordersHashCmd.Flags().StringVar(&maker, "maker", "", "")
-	ordersHashCmd.Flags().StringVar(&taker, "taker", "", "")
-	ordersHashCmd.Flags().StringVar(&makerTokenAddress, "maker-token-address", "", "")
-	ordersHashCmd.Flags().StringVar(&takerTokenAddress, "taker-token-address", "", "")
-	ordersHashCmd.Flags().StringVar(&feeRecipient, "fee-recipient", "", "")
 	ordersHashCmd.Flags().StringVar(&makerTokenAmount, "maker-token-amount", "", "")
 	ordersHashCmd.Flags().StringVar(&takerTokenAmount, "taker-token-amount", "", "")
 	ordersHashCmd.Flags().StringVar(&makerFee, "maker-fee", "", "")

--- a/cmd/orders_hash_test.go
+++ b/cmd/orders_hash_test.go
@@ -28,23 +28,7 @@ func (suite *OrdersHashSuite) TestOrdersHash() {
 		flags    []string
 		expected string
 	}{
-		{
-			[]string{
-				"--exchange-contract-address", "exchange-contract-address",
-				"--maker", "maker",
-				"--taker", "taker",
-				"--maker-token-address", "maker-token-address",
-				"--taker-token-address", "taker-token-address",
-				"--fee-recipient", "fee-recipient",
-				"--maker-token-amount", "1",
-				"--taker-token-amount", "2",
-				"--maker-fee", "3",
-				"--taker-fee", "4",
-				"--expiration-unix-timestamp-sec", "5",
-				"--salt", "6",
-			},
-			"0xb9522c02a6e351361a01403f7c140768baf9a7e5446beb1733bb0578f6612f94\n",
-		},
+		// RadarRelay
 		{
 			[]string{
 				"--exchange-contract-address", "0x12459c951127e0c374ff9105dda097662a027093",
@@ -61,6 +45,24 @@ func (suite *OrdersHashSuite) TestOrdersHash() {
 				"--salt", "58600101225676680041453168589125977076540694791976419610199695339725548478315",
 			},
 			"0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942\n",
+		},
+		// The Ocean X
+		{
+			[]string{
+				"--exchange-contract-address", "0x90fe2af704b34e0224bf2299c838e04d4dcf1364",
+				"--maker", "0x00a6d07f3530430f87e19c25d999b627f4fe32e2",
+				"--taker", "0x00ba938cc0df182c25108d7bf2ee3d37bce07513",
+				"--maker-token-address", "0x6ff6c0ff1d68b964901f986d4c9fa3ac68346570",
+				"--taker-token-address", "0xd0a1e359811322d97991e03f863a0c30c2cf029c",
+				"--fee-recipient", "0x88a64b5e882e5ad851bea5e7a3c8ba7c523fecbe",
+				"--maker-token-amount", "1000000000",
+				"--taker-token-amount", "1100000000",
+				"--maker-fee", "0",
+				"--taker-fee", "0",
+				"--expiration-unix-timestamp-sec", "1523097537",
+				"--salt", "96779178608164233712795994683330674094398651784855349948764786357549104359274",
+			},
+			"0x0bf9344a08234507fadfdc6040b4d941fdf82c89a5f8455508499e8b3d4739e7\n",
 		},
 	} {
 		args := append(

--- a/cmd/orders_list.go
+++ b/cmd/orders_list.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+
+	"github.com/linki/0x-go/relayer"
+)
+
+var (
+	tokenAddress string
+	trader       string
+)
+
+var (
+	ordersListCmd = &cobra.Command{
+		Use: "list",
+		Run: listOrders,
+	}
+)
+
+func init() {
+	ordersListCmd.Flags().StringVar(&tokenAddress, "token-address", "", "")
+	ordersListCmd.Flags().StringVar(&trader, "trader", "", "")
+
+	ordersCmd.AddCommand(ordersListCmd)
+}
+
+func listOrders(cmd *cobra.Command, _ []string) {
+	client := relayer.NewClient(relayerURL)
+
+	orders, err := client.GetOrders(context.Background(), relayer.GetOrdersOpts{
+		ExchangeContractAddress: common.HexToAddress(exchangeContractAddress),
+		TokenAddress:            common.HexToAddress(tokenAddress),
+		MakerTokenAddress:       common.HexToAddress(makerTokenAddress),
+		TakerTokenAddress:       common.HexToAddress(takerTokenAddress),
+		Maker:                   common.HexToAddress(maker),
+		Taker:                   common.HexToAddress(taker),
+		Trader:                  common.HexToAddress(trader),
+		FeeRecipient:            common.HexToAddress(feeRecipient),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, o := range orders {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", o.OrderHash.Hex())
+	}
+}

--- a/cmd/orders_list_test.go
+++ b/cmd/orders_list_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/suite"
+)
+
+type OrdersListSuite struct {
+	suite.Suite
+	console io.ReadWriter
+	url     string
+}
+
+func (suite *OrdersListSuite) SetupTest() {
+	suite.console = &bytes.Buffer{}
+	ordersListCmd.SetOutput(suite.console)
+
+	suite.url = "http://127.0.0.1:8080"
+}
+
+func (suite *OrdersListSuite) TearDownTest() {
+	ordersListCmd.SetOutput(nil)
+	suite.True(gock.IsDone())
+	gock.Off()
+}
+
+func (suite *OrdersListSuite) TestOrdersList() {
+	for _, tt := range []struct {
+		response       []map[string]interface{}
+		flags          []string
+		expectedParams map[string]string
+		expected       string
+	}{
+		{
+			[]map[string]interface{}{
+				{
+					"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+					"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+					"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+					"taker":                      "0x0000000000000000000000000000000000000000",
+					"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+					"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+					"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+					"makerTokenAmount":           "18981000000000000",
+					"takerTokenAmount":           "19000000000000000000",
+					"makerFee":                   "0",
+					"takerFee":                   "0",
+					"expirationUnixTimestampSec": "1518201120",
+					"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+					"ecSignature": map[string]interface{}{
+						"v": 28,
+						"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+						"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+					},
+				},
+			},
+			[]string{
+				"--relayer-url", suite.url,
+			},
+			map[string]string{},
+			"0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942\n",
+		},
+		{
+			[]map[string]interface{}{
+				{
+					"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+					"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+					"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+					"taker":                      "0x0000000000000000000000000000000000000000",
+					"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+					"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+					"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+					"makerTokenAmount":           "18981000000000000",
+					"takerTokenAmount":           "19000000000000000000",
+					"makerFee":                   "0",
+					"takerFee":                   "0",
+					"expirationUnixTimestampSec": "1518201120",
+					"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+					"ecSignature": map[string]interface{}{
+						"v": 28,
+						"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+						"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+					},
+				},
+			},
+			[]string{
+				"--relayer-url", suite.url,
+				"--exchange-contract-address", "0x12459c951127e0c374ff9105dda097662a027093",
+				"--token-address", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"--maker-token-address", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"--taker-token-address", "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"--maker", "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"--taker", "0x00ba938cc0df182c25108d7bf2ee3d37bce07513",
+				"--trader", "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"--fee-recipient", "0xa258b39954cef5cb142fd567a46cddb31a670124",
+			},
+			map[string]string{
+				"exchangeContractAddress": "0x12459c951127e0c374ff9105dda097662a027093",
+				"tokenAddress":            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"makerTokenAddress":       "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":       "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"maker":                   "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                   "0x00ba938cc0df182c25108d7bf2ee3d37bce07513",
+				"trader":                  "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"feeRecipient":            "0xa258b39954cef5cb142fd567a46cddb31a670124",
+			},
+			"0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942\n",
+		},
+	} {
+		gock.New(suite.url).
+			Get("/orders").
+			MatchParams(tt.expectedParams).
+			Reply(http.StatusOK).
+			JSON(tt.response)
+
+		args := append(
+			[]string{"orders", "list"},
+			tt.flags...,
+		)
+
+		rootCmd.SetArgs(args)
+		rootCmd.Execute()
+
+		output, err := ioutil.ReadAll(suite.console)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, string(output))
+	}
+}
+
+func TestOrdersListSuite(t *testing.T) {
+	suite.Run(t, new(OrdersListSuite))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,16 @@ import (
 )
 
 var (
+	relayerURL string
+)
+
+var (
 	rootCmd = &cobra.Command{}
 )
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&relayerURL, "relayer-url", "", "")
+}
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/tokens_pairs.go
+++ b/cmd/tokens_pairs.go
@@ -11,10 +11,6 @@ import (
 )
 
 var (
-	relayerURL string
-)
-
-var (
 	tokensPairsCmd = &cobra.Command{
 		Use: "pairs",
 		Run: listTokenPairs,
@@ -22,8 +18,6 @@ var (
 )
 
 func init() {
-	tokensPairsCmd.Flags().StringVar(&relayerURL, "url", "", "")
-
 	tokensCmd.AddCommand(tokensPairsCmd)
 }
 

--- a/cmd/tokens_pairs_test.go
+++ b/cmd/tokens_pairs_test.go
@@ -48,7 +48,7 @@ func (suite *TokensPairsSuite) TestTokensPairs() {
 				},
 			},
 			[]string{
-				"--url", suite.url,
+				"--relayer-url", suite.url,
 			},
 			"0x323b5d4c32345ced77393b3530b1eed0f346429d 0xef7fff64389b814a946f3e92105513705ca6b990\n",
 		},

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -6,8 +6,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/linki/0x-go/types"
+	"github.com/linki/0x-go/util"
 )
 
 type Client struct {
@@ -50,4 +55,77 @@ func (c *Client) GetTokenPairs(ctx context.Context) ([]types.TokenPair, error) {
 	}
 
 	return tokenPairs, nil
+}
+
+type GetOrdersOpts struct {
+	ExchangeContractAddress common.Address
+	TokenAddress            common.Address
+	MakerTokenAddress       common.Address
+	TakerTokenAddress       common.Address
+	Maker                   common.Address
+	Taker                   common.Address
+	Trader                  common.Address
+	FeeRecipient            common.Address
+}
+
+func (c *Client) GetOrders(ctx context.Context, opts GetOrdersOpts) ([]types.Order, error) {
+	reqURL, err := url.Parse(c.url + "/orders")
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if !util.EmptyAddress(opts.ExchangeContractAddress) {
+		query["exchangeContractAddress"] = []string{strings.ToLower(opts.ExchangeContractAddress.Hex())}
+	}
+	if !util.EmptyAddress(opts.TokenAddress) {
+		query["tokenAddress"] = []string{strings.ToLower(opts.TokenAddress.Hex())}
+	}
+	if !util.EmptyAddress(opts.MakerTokenAddress) {
+		query["makerTokenAddress"] = []string{strings.ToLower(opts.MakerTokenAddress.Hex())}
+	}
+	if !util.EmptyAddress(opts.TakerTokenAddress) {
+		query["takerTokenAddress"] = []string{strings.ToLower(opts.TakerTokenAddress.Hex())}
+	}
+	if !util.EmptyAddress(opts.Maker) {
+		query["maker"] = []string{strings.ToLower(opts.Maker.Hex())}
+	}
+	if !util.EmptyAddress(opts.Taker) {
+		query["taker"] = []string{strings.ToLower(opts.Taker.Hex())}
+	}
+	if !util.EmptyAddress(opts.Trader) {
+		query["trader"] = []string{strings.ToLower(opts.Trader.Hex())}
+	}
+	if !util.EmptyAddress(opts.FeeRecipient) {
+		query["feeRecipient"] = []string{strings.ToLower(opts.FeeRecipient.Hex())}
+	}
+	reqURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("erroneous status code: %s", resp.Status)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	orders := []types.Order{}
+
+	if err := json.Unmarshal(respBody, &orders); err != nil {
+		return nil, fmt.Errorf("error parsing json response: %v", err)
+	}
+
+	return orders, nil
 }

--- a/relayer/client_test.go
+++ b/relayer/client_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/linki/0x-go/types"
+	"github.com/linki/0x-go/util"
 
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/suite"
@@ -45,6 +49,8 @@ func (suite *ClientSuite) TearDownTest() {
 	suite.True(gock.IsDone())
 	gock.Off()
 }
+
+// GET /token_pairs
 
 func (suite *ClientSuite) TestGetTokenPairs() {
 	gock.New(suite.url).
@@ -101,6 +107,125 @@ func (suite *ClientSuite) TestGetTokenPairsWithContext() {
 	cancel()
 
 	_, err := suite.client.GetTokenPairs(ctx)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "context canceled")
+}
+
+// GET /orders
+
+func (suite *ClientSuite) TestGetOrders() {
+	gock.New(suite.url).
+		Get("/orders").
+		Reply(http.StatusOK).
+		JSON([]map[string]interface{}{
+			{
+				"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+				"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+				"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                      "0x0000000000000000000000000000000000000000",
+				"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+				"makerTokenAmount":           "18981000000000000",
+				"takerTokenAmount":           "19000000000000000000",
+				"makerFee":                   "0",
+				"takerFee":                   "0",
+				"expirationUnixTimestampSec": "1518201120",
+				"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"ecSignature": map[string]interface{}{
+					"v": 28,
+					"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+					"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+				},
+			},
+		})
+
+	order := types.Order{
+		OrderHash:               common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"),
+		Maker:                   common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+		Taker:                   common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		FeeRecipient:            common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+		MakerTokenAddress:       common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+		TakerTokenAddress:       common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+		ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+		Salt:                       util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"),
+		MakerFee:                   common.Big0,
+		TakerFee:                   common.Big0,
+		MakerTokenAmount:           util.StrToBig("18981000000000000"),
+		TakerTokenAmount:           util.StrToBig("19000000000000000000"),
+		ExpirationUnixTimestampSec: time.Unix(1518201120, 0),
+		Signature: types.Signature{
+			V: 28,
+			R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
+			S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
+		},
+	}
+
+	orders, err := suite.client.GetOrders(context.Background(), GetOrdersOpts{})
+	suite.NoError(err)
+
+	suite.Require().Len(orders, 1)
+	suite.Equal(order, orders[0])
+}
+
+func (suite *ClientSuite) TestGetOrdersWithFilters() {
+	gock.New(suite.url).
+		Get("/orders").
+		MatchParams(map[string]string{
+			"exchangeContractAddress": "0x12459c951127e0c374ff9105dda097662a027093",
+			"tokenAddress":            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+			"makerTokenAddress":       "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+			"takerTokenAddress":       "0xe41d2489571d322189246dafa5ebde1f4699f498",
+			"maker":                   "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+			"taker":                   "0x00ba938cc0df182c25108d7bf2ee3d37bce07513",
+			"trader":                  "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+			"feeRecipient":            "0xa258b39954cef5cb142fd567a46cddb31a670124",
+		}).
+		Reply(http.StatusOK).
+		JSON([]map[string]interface{}{})
+
+	orders, err := suite.client.GetOrders(context.Background(), GetOrdersOpts{
+		ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+		TokenAddress:            common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+		MakerTokenAddress:       common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+		TakerTokenAddress:       common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+		Maker:                   common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+		Taker:                   common.HexToAddress("0x00ba938cc0df182c25108d7bf2ee3d37bce07513"),
+		Trader:                  common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+		FeeRecipient:            common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+	})
+	suite.NoError(err)
+
+	suite.Len(orders, 0)
+}
+
+func (suite *ClientSuite) TestGetOrdersWithUnsuccessfulResponse() {
+	gock.New(suite.url).
+		Get("/orders").
+		Reply(http.StatusServiceUnavailable)
+
+	_, err := suite.client.GetOrders(context.Background(), GetOrdersOpts{})
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "erroneous status code")
+	suite.Contains(err.Error(), "503 Service Unavailable")
+}
+
+func (suite *ClientSuite) TestGetOrdersWithMalformedJSON() {
+	gock.New(suite.url).
+		Get("/orders").
+		Reply(http.StatusOK).
+		BodyString("//\\")
+
+	_, err := suite.client.GetOrders(context.Background(), GetOrdersOpts{})
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "error parsing json response")
+}
+
+func (suite *ClientSuite) TestGetTOrdersWithContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := suite.client.GetOrders(ctx, GetOrdersOpts{})
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "context canceled")
 }

--- a/types/order_test.go
+++ b/types/order_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"math/big"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -17,23 +17,101 @@ type OrderSuite struct {
 }
 
 func (suite *OrderSuite) TestCalculateOrderHash() {
-	order := Order{
-		ExchangeContractAddress: common.HexToAddress("0xCcEF5Ce0a59D4CA4a942302002Eb0bf64Ab00D10"),
-		Maker:                      common.HexToAddress("0xadD132AD2b945CDBDC4Dd51C32744bfA4D5fC28d"),
-		Taker:                      common.HexToAddress("0x0000000000000000000000000000000000000000"),
-		MakerTokenAddress:          common.HexToAddress("0x6ba494043E22755c8D626739b2Ff7305D76ef7ec"),
-		TakerTokenAddress:          common.HexToAddress("0x672E9578A90d79f1d817e0197937635c00c76352"),
-		FeeRecipient:               common.HexToAddress("0xBdF0bF6Bba29B55199Ba7f0895a797a2037080DC"),
-		MakerTokenAmount:           util.StrToBig("20000000000000000000"),
-		TakerTokenAmount:           util.StrToBig("10000000000000000000"),
-		MakerFee:                   common.Big0,
-		TakerFee:                   common.Big0,
-		ExpirationUnixTimestampSec: time.Date(2018, 2, 8, 18, 0, 0, 0, time.UTC),
-		Salt: big.NewInt(42),
+	for _, tt := range []struct {
+		order    Order
+		expected common.Hash
+	}{
+		// RadarRelay
+		{
+			Order{
+				ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+				Maker:                      common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+				Taker:                      common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				MakerTokenAddress:          common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+				TakerTokenAddress:          common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+				FeeRecipient:               common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+				MakerTokenAmount:           util.StrToBig("18981000000000000"),
+				TakerTokenAmount:           util.StrToBig("19000000000000000000"),
+				MakerFee:                   common.Big0,
+				TakerFee:                   common.Big0,
+				ExpirationUnixTimestampSec: time.Unix(1518201120, 0),
+				Salt: util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"),
+			},
+			common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"),
+		},
+		// The Ocean X
+		{
+			Order{
+				ExchangeContractAddress: common.HexToAddress("0x90fe2af704b34e0224bf2299c838e04d4dcf1364"),
+				Maker:                      common.HexToAddress("0x00a6d07f3530430f87e19c25d999b627f4fe32e2"),
+				Taker:                      common.HexToAddress("0x00ba938cc0df182c25108d7bf2ee3d37bce07513"),
+				MakerTokenAddress:          common.HexToAddress("0x6ff6c0ff1d68b964901f986d4c9fa3ac68346570"),
+				TakerTokenAddress:          common.HexToAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
+				FeeRecipient:               common.HexToAddress("0x88a64b5e882e5ad851bea5e7a3c8ba7c523fecbe"),
+				MakerTokenAmount:           util.StrToBig("1000000000"),
+				TakerTokenAmount:           util.StrToBig("1100000000"),
+				MakerFee:                   common.Big0,
+				TakerFee:                   common.Big0,
+				ExpirationUnixTimestampSec: time.Unix(1523097537, 0),
+				Salt: util.StrToBig("96779178608164233712795994683330674094398651784855349948764786357549104359274"),
+			},
+			common.HexToHash("0x0bf9344a08234507fadfdc6040b4d941fdf82c89a5f8455508499e8b3d4739e7"),
+		},
+	} {
+		suite.Equal(tt.expected, tt.order.CalculateOrderHash())
 	}
-	orderHash := common.HexToHash("0x8aa8e6cbe04f63443a71fd43d511883087df205e7b47f479bc616713d13ce0c7")
+}
 
-	suite.Equal(orderHash, order.CalculateOrderHash())
+func (suite *OrderSuite) TestUnmarshal() {
+	jsonStr := `[
+		{
+			"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+			"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+			"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+			"taker":                      "0x0000000000000000000000000000000000000000",
+			"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+			"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+			"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+			"makerTokenAmount":           "18981000000000000",
+			"takerTokenAmount":           "19000000000000000000",
+			"makerFee":                   "0",
+			"takerFee":                   "0",
+			"expirationUnixTimestampSec": "1518201120",
+			"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+			"ecSignature": {
+				"v": 28,
+				"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+				"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"
+			}
+		}
+	]`
+
+	orders := []Order{}
+
+	err := json.Unmarshal([]byte(jsonStr), &orders)
+	suite.Require().NoError(err)
+
+	suite.Require().Len(orders, 1)
+	order := orders[0]
+
+	suite.Equal(common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"), order.OrderHash)
+	suite.Equal(common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"), order.ExchangeContractAddress)
+	suite.Equal(common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"), order.Maker)
+	suite.Equal(common.HexToAddress("0x0000000000000000000000000000000000000000"), order.Taker)
+	suite.Equal(common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"), order.MakerTokenAddress)
+	suite.Equal(common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"), order.TakerTokenAddress)
+	suite.Equal(common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"), order.FeeRecipient)
+	suite.Equal(util.StrToBig("18981000000000000"), order.MakerTokenAmount)
+	suite.Equal(util.StrToBig("19000000000000000000"), order.TakerTokenAmount)
+	suite.Equal(common.Big0, order.MakerFee)
+	suite.Equal(common.Big0, order.TakerFee)
+	suite.Equal(time.Unix(1518201120, 0), order.ExpirationUnixTimestampSec)
+	suite.Equal(util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"), order.Salt)
+	suite.Equal(Signature{
+		V: 28,
+		R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
+		S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
+	}, order.Signature)
 }
 
 func TestOrderSuite(t *testing.T) {

--- a/types/signature.go
+++ b/types/signature.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Signature struct {
+	V byte
+	R common.Hash
+	S common.Hash
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,7 +2,13 @@ package util
 
 import (
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
 )
+
+func EmptyAddress(a common.Address) bool {
+	return common.EmptyHash(a.Hash())
+}
 
 func StrToBig(str string) *big.Int {
 	bigInt, ok := new(big.Int).SetString(str, 10)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,11 +4,18 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/suite"
 )
 
 type UtilSuite struct {
 	suite.Suite
+}
+
+func (suite *UtilSuite) TestEmptyAddress() {
+	suite.True(EmptyAddress(common.HexToAddress("0x0000000000000000000000000000000000000000")))
+	suite.False(EmptyAddress(common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")))
 }
 
 func (suite *UtilSuite) TestStrToBig() {


### PR DESCRIPTION
```console
$ go run main.go orders list --relayer-url https://api.radarrelay.com/0x/v0 --maker 0xf8741c4a6ac71d661a37fabc91b3e2f3244db3dd
0xd209e09133c8eb83a70d176676a6a574a0a26ac46df74b96b03fb239dcdc31dc
0x126a0e240dced34ca6415c4be0480a3e9a1ddf22eead067f0f9bd3dc22c0f74f
0x6d460e9602b0256ab2fdc5a663d7bb702681c22933e6f8c6800e744d4c686cec
...
```