### PR TITLE
Add command to get details about a relayer's order

### DIFF
--- a/cmd/orders_describe.go
+++ b/cmd/orders_describe.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/linki/0x-go/relayer"
+)
+
+var (
+	orderHash string
+)
+
+var (
+	ordersDescribeCmd = &cobra.Command{
+		Use: "describe",
+		Run: describeOrders,
+	}
+)
+
+func init() {
+	ordersDescribeCmd.Flags().StringVar(&orderHash, "order-hash", "", "")
+
+	ordersCmd.AddCommand(ordersDescribeCmd)
+}
+
+func describeOrders(cmd *cobra.Command, _ []string) {
+	client := relayer.NewClient(relayerURL)
+
+	order, err := client.GetOrder(context.Background(), common.HexToHash(orderHash))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	orderFmt := `orderHash: %s
+exchange-contract-address: %s
+maker: %s
+taker: %s
+maker-token-address: %s
+taker-token-address: %s
+fee-recipient: %s
+maker-token-amount: %s
+taker-token-amount: %s
+maker-fee: %s
+taker-fee: %s
+expiration-unix-timestamp-sec: %d
+salt: %s
+v: %d
+r: %s
+s: %s
+`
+
+	fmt.Fprintf(cmd.OutOrStdout(), orderFmt,
+		order.OrderHash.Hex(),
+		strings.ToLower(order.ExchangeContractAddress.Hex()),
+		strings.ToLower(order.Maker.Hex()),
+		strings.ToLower(order.Taker.Hex()),
+		strings.ToLower(order.MakerTokenAddress.Hex()),
+		strings.ToLower(order.TakerTokenAddress.Hex()),
+		strings.ToLower(order.FeeRecipient.Hex()),
+		order.MakerTokenAmount,
+		order.TakerTokenAmount,
+		order.MakerFee,
+		order.TakerFee,
+		order.ExpirationUnixTimestampSec.Unix(),
+		order.Salt,
+		order.Signature.V,
+		order.Signature.R.Hex(),
+		order.Signature.S.Hex(),
+	)
+}

--- a/cmd/orders_describe_test.go
+++ b/cmd/orders_describe_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/suite"
+)
+
+type OrdersDescribeSuite struct {
+	suite.Suite
+	console io.ReadWriter
+	url     string
+}
+
+func (suite *OrdersDescribeSuite) SetupTest() {
+	suite.console = &bytes.Buffer{}
+	ordersDescribeCmd.SetOutput(suite.console)
+
+	suite.url = "http://127.0.0.1:8080"
+}
+
+func (suite *OrdersDescribeSuite) TearDownTest() {
+	ordersDescribeCmd.SetOutput(nil)
+	suite.True(gock.IsDone())
+	gock.Off()
+}
+
+func (suite *OrdersDescribeSuite) TestOrdersDescribe() {
+	for _, tt := range []struct {
+		response map[string]interface{}
+		flags    []string
+		expected string
+	}{
+		{
+			map[string]interface{}{
+				"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+				"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+				"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                      "0x0000000000000000000000000000000000000000",
+				"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+				"makerTokenAmount":           "18981000000000000",
+				"takerTokenAmount":           "19000000000000000000",
+				"makerFee":                   "0",
+				"takerFee":                   "0",
+				"expirationUnixTimestampSec": "1518201120",
+				"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"ecSignature": map[string]interface{}{
+					"v": 28,
+					"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+					"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+				},
+			},
+			[]string{
+				"--relayer-url", suite.url,
+				"--order-hash", "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+			},
+			`orderHash: 0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942
+exchange-contract-address: 0x12459c951127e0c374ff9105dda097662a027093
+maker: 0xc9b32e9563fe99612ce3a2695ac2a6404c111dde
+taker: 0x0000000000000000000000000000000000000000
+maker-token-address: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+taker-token-address: 0xe41d2489571d322189246dafa5ebde1f4699f498
+fee-recipient: 0xa258b39954cef5cb142fd567a46cddb31a670124
+maker-token-amount: 18981000000000000
+taker-token-amount: 19000000000000000000
+maker-fee: 0
+taker-fee: 0
+expiration-unix-timestamp-sec: 1518201120
+salt: 58600101225676680041453168589125977076540694791976419610199695339725548478315
+v: 28
+r: 0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9
+s: 0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709
+`,
+		},
+	} {
+		gock.New(suite.url).
+			Get("/order/0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942").
+			Reply(http.StatusOK).
+			JSON(tt.response)
+
+		args := append(
+			[]string{"orders", "describe"},
+			tt.flags...,
+		)
+
+		rootCmd.SetArgs(args)
+		rootCmd.Execute()
+
+		output, err := ioutil.ReadAll(suite.console)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, string(output))
+	}
+}
+
+func TestOrdersDescribeSuite(t *testing.T) {
+	suite.Run(t, new(OrdersDescribeSuite))
+}

--- a/relayer/client_test.go
+++ b/relayer/client_test.go
@@ -230,6 +230,103 @@ func (suite *ClientSuite) TestGetOrdersWithContext() {
 	suite.Contains(err.Error(), "context canceled")
 }
 
+// GET /orders/orderHash
+
+func (suite *ClientSuite) TestGetOrder() {
+	gock.New(suite.url).
+		Get("/order/0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942").
+		Reply(http.StatusOK).
+		JSON(map[string]interface{}{
+			"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+			"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+			"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+			"taker":                      "0x0000000000000000000000000000000000000000",
+			"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+			"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+			"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+			"makerTokenAmount":           "18981000000000000",
+			"takerTokenAmount":           "19000000000000000000",
+			"makerFee":                   "0",
+			"takerFee":                   "0",
+			"expirationUnixTimestampSec": "1518201120",
+			"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+			"ecSignature": map[string]interface{}{
+				"v": 28,
+				"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+				"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+			},
+		})
+
+	order := types.Order{
+		OrderHash:               common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"),
+		Maker:                   common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+		Taker:                   common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		FeeRecipient:            common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+		MakerTokenAddress:       common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+		TakerTokenAddress:       common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+		ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+		Salt:                       util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"),
+		MakerFee:                   common.Big0,
+		TakerFee:                   common.Big0,
+		MakerTokenAmount:           util.StrToBig("18981000000000000"),
+		TakerTokenAmount:           util.StrToBig("19000000000000000000"),
+		ExpirationUnixTimestampSec: time.Unix(1518201120, 0),
+		Signature: types.Signature{
+			V: 28,
+			R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
+			S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
+		},
+	}
+
+	order, err := suite.client.GetOrder(context.Background(), common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"))
+	suite.NoError(err)
+
+	suite.Equal(order, order)
+}
+
+func (suite *ClientSuite) TestGetOrderOrderNotFound() {
+	gock.New(suite.url).
+		Get("/order/0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942").
+		Reply(http.StatusNotFound).
+		JSON(map[string]interface{}{})
+
+	_, err := suite.client.GetOrder(context.Background(), common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"))
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "order not found")
+	suite.Contains(err.Error(), "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942")
+}
+
+func (suite *ClientSuite) TestGetOrderWithUnsuccessfulResponse() {
+	gock.New(suite.url).
+		Get("/order/0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942").
+		Reply(http.StatusServiceUnavailable)
+
+	_, err := suite.client.GetOrder(context.Background(), common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"))
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "erroneous status code")
+	suite.Contains(err.Error(), "503 Service Unavailable")
+}
+
+func (suite *ClientSuite) TestGetOrderWithMalformedJSON() {
+	gock.New(suite.url).
+		Get("/order/0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942").
+		Reply(http.StatusOK).
+		BodyString("//\\")
+
+	_, err := suite.client.GetOrder(context.Background(), common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"))
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "error parsing json response")
+}
+
+func (suite *ClientSuite) TestGetOrderWithContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := suite.client.GetOrder(ctx, common.Hash{})
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "context canceled")
+}
+
 func TestClientSuite(t *testing.T) {
 	suite.Run(t, new(ClientSuite))
 }

--- a/types/order.go
+++ b/types/order.go
@@ -54,7 +54,6 @@ func (o *Order) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	o.OrderHash = common.HexToHash(order["orderHash"].(string))
 	o.ExchangeContractAddress = common.HexToAddress(order["exchangeContractAddress"].(string))
 	o.Maker = common.HexToAddress(order["maker"].(string))
 	o.Taker = common.HexToAddress(order["taker"].(string))
@@ -86,6 +85,13 @@ func (o *Order) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	o.ExpirationUnixTimestampSec = time.Unix(timestamp, 0)
+
+	// When the JSON doesn't contain an order hash, we calculate it ourself.
+	if order["orderHash"] != nil {
+		o.OrderHash = common.HexToHash(order["orderHash"].(string))
+	} else {
+		o.OrderHash = o.CalculateOrderHash()
+	}
 
 	return nil
 }

--- a/types/order_test.go
+++ b/types/order_test.go
@@ -63,55 +63,89 @@ func (suite *OrderSuite) TestCalculateOrderHash() {
 }
 
 func (suite *OrderSuite) TestUnmarshal() {
-	jsonStr := `[
+	expectedOrders := []Order{
 		{
-			"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
-			"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
-			"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
-			"taker":                      "0x0000000000000000000000000000000000000000",
-			"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-			"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
-			"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
-			"makerTokenAmount":           "18981000000000000",
-			"takerTokenAmount":           "19000000000000000000",
-			"makerFee":                   "0",
-			"takerFee":                   "0",
-			"expirationUnixTimestampSec": "1518201120",
-			"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
-			"ecSignature": {
-				"v": 28,
-				"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
-				"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"
-			}
-		}
-	]`
+			OrderHash:               common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"),
+			Maker:                   common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+			Taker:                   common.HexToAddress("0x0000000000000000000000000000000000000000"),
+			FeeRecipient:            common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+			MakerTokenAddress:       common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+			TakerTokenAddress:       common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+			ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+			Salt:                       util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"),
+			MakerFee:                   common.Big0,
+			TakerFee:                   common.Big0,
+			MakerTokenAmount:           util.StrToBig("18981000000000000"),
+			TakerTokenAmount:           util.StrToBig("19000000000000000000"),
+			ExpirationUnixTimestampSec: time.Unix(1518201120, 0),
+			Signature: Signature{
+				V: 28,
+				R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
+				S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
+			},
+		},
+	}
 
-	orders := []Order{}
+	for _, tt := range []struct {
+		jsonStr string
+	}{
+		// JSON doesn't contain order hash (RadarRelay)
+		{
+			`[
+					{
+						"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+						"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+						"taker":                      "0x0000000000000000000000000000000000000000",
+						"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+						"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+						"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+						"makerTokenAmount":           "18981000000000000",
+						"takerTokenAmount":           "19000000000000000000",
+						"makerFee":                   "0",
+						"takerFee":                   "0",
+						"expirationUnixTimestampSec": "1518201120",
+						"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+						"ecSignature": {
+							"v": 28,
+							"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+							"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"
+						}
+					}
+			]`,
+		},
+		// JSON contains order hash (The Ocean X)
+		{
+			`[
+					{
+						"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+						"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+						"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+						"taker":                      "0x0000000000000000000000000000000000000000",
+						"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+						"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+						"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+						"makerTokenAmount":           "18981000000000000",
+						"takerTokenAmount":           "19000000000000000000",
+						"makerFee":                   "0",
+						"takerFee":                   "0",
+						"expirationUnixTimestampSec": "1518201120",
+						"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+						"ecSignature": {
+							"v": 28,
+							"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+							"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"
+						}
+					}
+			]`,
+		},
+	} {
+		orders := []Order{}
 
-	err := json.Unmarshal([]byte(jsonStr), &orders)
-	suite.Require().NoError(err)
+		err := json.Unmarshal([]byte(tt.jsonStr), &orders)
+		suite.Require().NoError(err)
 
-	suite.Require().Len(orders, 1)
-	order := orders[0]
-
-	suite.Equal(common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"), order.OrderHash)
-	suite.Equal(common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"), order.ExchangeContractAddress)
-	suite.Equal(common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"), order.Maker)
-	suite.Equal(common.HexToAddress("0x0000000000000000000000000000000000000000"), order.Taker)
-	suite.Equal(common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"), order.MakerTokenAddress)
-	suite.Equal(common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"), order.TakerTokenAddress)
-	suite.Equal(common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"), order.FeeRecipient)
-	suite.Equal(util.StrToBig("18981000000000000"), order.MakerTokenAmount)
-	suite.Equal(util.StrToBig("19000000000000000000"), order.TakerTokenAmount)
-	suite.Equal(common.Big0, order.MakerFee)
-	suite.Equal(common.Big0, order.TakerFee)
-	suite.Equal(time.Unix(1518201120, 0), order.ExpirationUnixTimestampSec)
-	suite.Equal(util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"), order.Salt)
-	suite.Equal(Signature{
-		V: 28,
-		R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
-		S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
-	}, order.Signature)
+		suite.Equal(expectedOrders, orders)
+	}
 }
 
 func TestOrderSuite(t *testing.T) {


### PR DESCRIPTION
```console
$ go run main.go orders describe --order-hash 0xe0c09a3046d2f0b46d8db2665b6d149380b7264bfcce1887cefba30165e1102b --relayer-url https://api.radarrelay.com/0x/v0
orderHash: 0xe0c09a3046d2f0b46d8db2665b6d149380b7264bfcce1887cefba30165e1102b
exchange-contract-address: 0x12459c951127e0c374ff9105dda097662a027093
maker: 0x3c1e5807e023622af499e1024954961ba865ed33
taker: 0x0000000000000000000000000000000000000000
maker-token-address: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
taker-token-address: 0xe41d2489571d322189246dafa5ebde1f4699f498
fee-recipient: 0xa258b39954cef5cb142fd567a46cddb31a670124
maker-token-amount: 449622225000000000
taker-token-amount: 512390000000000000000
maker-fee: 0
taker-fee: 0
expiration-unix-timestamp-sec: 1520619311
salt: 73758792450744654058563218865658523372187639966613601312062359972648144770156
v: 27
r: 0x4de7620e75935cda229da07df969bd28e77d1b91f62680ba2cc260c59344909e
s: 0x4d8abbd04290fe2adb5a135419b3e1a2b4b622f366783c6de28dc3be83ce644b
```