### PR TITLE
Use roveralls to aggregate coverage results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ matrix:
 
 install:
 - go get github.com/mattn/goveralls
+- go get github.com/lawrencewoodman/roveralls
 - go get github.com/golang/dep/cmd/dep
 - dep ensure -vendor-only
 
 script:
-- goveralls -service=travis-ci
+- roveralls
+- goveralls -coverprofile=roveralls.coverprofile -service=travis-ci


### PR DESCRIPTION
Let's use the excellent [roveralls](https://github.com/lawrencewoodman/roveralls) to aggregate coverrage reports across packages.

Thanks @lawrencewoodman 😃 