### PR TITLE
Allow to filter token pairs

### DIFF
--- a/cmd/tokens_pairs.go
+++ b/cmd/tokens_pairs.go
@@ -7,7 +7,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/linki/0x-go/relayer"
+)
+
+var (
+	tokenA string
+	tokenB string
 )
 
 var (
@@ -18,13 +25,19 @@ var (
 )
 
 func init() {
+	tokensPairsCmd.Flags().StringVar(&tokenA, "token-a", "", "")
+	tokensPairsCmd.Flags().StringVar(&tokenB, "token-b", "", "")
+
 	tokensCmd.AddCommand(tokensPairsCmd)
 }
 
 func listTokenPairs(cmd *cobra.Command, _ []string) {
 	client := relayer.NewClient(relayerURL)
 
-	tokenPairs, err := client.GetTokenPairs(context.Background())
+	tokenPairs, err := client.GetTokenPairs(context.Background(), relayer.GetTokenPairsOpts{
+		TokenA: common.HexToAddress(tokenA),
+		TokenB: common.HexToAddress(tokenB),
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tokens_pairs_test.go
+++ b/cmd/tokens_pairs_test.go
@@ -32,9 +32,10 @@ func (suite *TokensPairsSuite) TearDownTest() {
 
 func (suite *TokensPairsSuite) TestTokensPairs() {
 	for _, tt := range []struct {
-		response []map[string]interface{}
-		flags    []string
-		expected string
+		response       []map[string]interface{}
+		flags          []string
+		expectedParams map[string]string
+		expected       string
 	}{
 		{
 			[]map[string]interface{}{
@@ -49,12 +50,19 @@ func (suite *TokensPairsSuite) TestTokensPairs() {
 			},
 			[]string{
 				"--relayer-url", suite.url,
+				"--token-a", "0x323b5d4c32345ced77393b3530b1eed0f346429d",
+				"--token-b", "0xef7fff64389b814a946f3e92105513705ca6b990",
+			},
+			map[string]string{
+				"tokenA": "0x323b5d4c32345ced77393b3530b1eed0f346429d",
+				"tokenB": "0xef7fff64389b814a946f3e92105513705ca6b990",
 			},
 			"0x323b5d4c32345ced77393b3530b1eed0f346429d 0xef7fff64389b814a946f3e92105513705ca6b990\n",
 		},
 	} {
 		gock.New(suite.url).
 			Get("/token_pairs").
+			MatchParams(tt.expectedParams).
 			Reply(http.StatusOK).
 			JSON(tt.response)
 

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -27,8 +27,27 @@ func NewClient(url string) *Client {
 	}
 }
 
-func (c *Client) GetTokenPairs(ctx context.Context) ([]types.TokenPair, error) {
-	req, err := http.NewRequest(http.MethodGet, c.url+"/token_pairs", nil)
+type GetTokenPairsOpts struct {
+	TokenA common.Address
+	TokenB common.Address
+}
+
+func (c *Client) GetTokenPairs(ctx context.Context, opts GetTokenPairsOpts) ([]types.TokenPair, error) {
+	reqURL, err := url.Parse(c.url + "/token_pairs")
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if !util.EmptyAddress(opts.TokenA) {
+		query["tokenA"] = []string{strings.ToLower(opts.TokenA.Hex())}
+	}
+	if !util.EmptyAddress(opts.TokenB) {
+		query["tokenB"] = []string{strings.ToLower(opts.TokenB.Hex())}
+	}
+	reqURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```console
$ go run main.go tokens pairs --token-a 0xe41d2489571d322189246dafa5ebde1f4699f498 --relayer-url https://api.radarrelay.com/0x/v0
0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359 0xe41d2489571d322189246dafa5ebde1f4699f498
0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 0xe41d2489571d322189246dafa5ebde1f4699f498
```