### PR TITLE
Add commands to sign and create orders

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,18 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/aristanetworks/goarista"
+  packages = ["monotime"]
+  revision = "9cf7f6b188ea30684caffe3d18e03e61d7193e25"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/btcsuite/btcd"
+  packages = ["btcec"]
+  revision = "2be2f12b358dc57d70b8f501b00be450192efbc3"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -10,12 +22,40 @@
 [[projects]]
   name = "github.com/ethereum/go-ethereum"
   packages = [
+    ".",
+    "accounts",
+    "accounts/keystore",
     "common",
     "common/hexutil",
-    "crypto/sha3"
+    "common/math",
+    "common/mclock",
+    "core/types",
+    "crypto",
+    "crypto/randentropy",
+    "crypto/secp256k1",
+    "crypto/sha3",
+    "ethdb",
+    "event",
+    "log",
+    "metrics",
+    "params",
+    "rlp",
+    "trie"
   ]
   revision = "b8b9f7f4476a30a0aaf6077daade6ae77f969960"
   version = "v1.8.2"
+
+[[projects]]
+  name = "github.com/go-stack/stack"
+  packages = ["."]
+  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
+  version = "v1.7.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
   name = "github.com/h2non/gock"
@@ -30,10 +70,22 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
+  version = "v1.1"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/rjeczalik/notify"
+  packages = ["."]
+  revision = "d152f3ce359a5464dc41e84a8919fc67e55bbbf0"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -65,8 +117,31 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/syndtr/goleveldb"
+  packages = [
+    "leveldb",
+    "leveldb/cache",
+    "leveldb/comparer",
+    "leveldb/errors",
+    "leveldb/filter",
+    "leveldb/iterator",
+    "leveldb/journal",
+    "leveldb/memdb",
+    "leveldb/opt",
+    "leveldb/storage",
+    "leveldb/table",
+    "leveldb/util"
+  ]
+  revision = "169b1b37be738edb2813dab48c97a549bcf99bb5"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "pbkdf2",
+    "scrypt",
+    "ssh/terminal"
+  ]
   revision = "85f98707c97e11569271e4d9b3d397e079c4f4d0"
 
 [[projects]]
@@ -78,9 +153,21 @@
   ]
   revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
 
+[[projects]]
+  name = "gopkg.in/fatih/set.v0"
+  packages = ["."]
+  revision = "57907de300222151a123d29255ed17f5ed43fad3"
+  version = "v0.1.0"
+
+[[projects]]
+  branch = "v2"
+  name = "gopkg.in/karalabe/cookiejar.v2"
+  packages = ["collections/prque"]
+  revision = "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "90d9d728b0ca14902afff6faceb2536e88810e10a05ca343a811351749da8b6d"
+  inputs-digest = "822652dcbd4ea415ee9037c862e6fcb17237c5b6eb17abac7b782151cde0d7a4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/orders.go
+++ b/cmd/orders.go
@@ -1,16 +1,32 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 )
 
 var (
-	exchangeContractAddress string
-	makerTokenAddress       string
-	takerTokenAddress       string
-	maker                   string
-	taker                   string
-	feeRecipient            string
+	orderHash                  string
+	exchangeContractAddress    string
+	makerTokenAddress          string
+	takerTokenAddress          string
+	maker                      string
+	taker                      string
+	feeRecipient               string
+	makerTokenAmount           string
+	takerTokenAmount           string
+	makerFee                   string
+	takerFee                   string
+	expirationUnixTimestampSec int64
+	salt                       string
+
+	keystoreFile string
+	passphrase   string
 )
 
 var (
@@ -20,12 +36,45 @@ var (
 )
 
 func init() {
+	ordersCmd.PersistentFlags().StringVar(&orderHash, "order-hash", "", "")
 	ordersCmd.PersistentFlags().StringVar(&exchangeContractAddress, "exchange-contract-address", "", "")
 	ordersCmd.PersistentFlags().StringVar(&maker, "maker", "", "")
 	ordersCmd.PersistentFlags().StringVar(&taker, "taker", "", "")
 	ordersCmd.PersistentFlags().StringVar(&makerTokenAddress, "maker-token-address", "", "")
 	ordersCmd.PersistentFlags().StringVar(&takerTokenAddress, "taker-token-address", "", "")
 	ordersCmd.PersistentFlags().StringVar(&feeRecipient, "fee-recipient", "", "")
+	ordersCmd.PersistentFlags().StringVar(&makerTokenAmount, "maker-token-amount", "", "")
+	ordersCmd.PersistentFlags().StringVar(&takerTokenAmount, "taker-token-amount", "", "")
+	ordersCmd.PersistentFlags().StringVar(&makerFee, "maker-fee", "", "")
+	ordersCmd.PersistentFlags().StringVar(&takerFee, "taker-fee", "", "")
+	ordersCmd.PersistentFlags().Int64Var(&expirationUnixTimestampSec, "expiration-unix-timestamp-sec", 0, "")
+	ordersCmd.PersistentFlags().StringVar(&salt, "salt", "", "")
+
+	ordersCmd.PersistentFlags().StringVar(&keystoreFile, "keystore-file", "", "")
+	ordersCmd.PersistentFlags().StringVar(&passphrase, "passphrase", "", "")
 
 	rootCmd.AddCommand(ordersCmd)
+}
+
+func loadPrivateKey() (*keystore.Key, error) {
+	// Open the provided Keystore file.
+	keyStoreFile, err := os.OpenFile(keystoreFile, os.O_RDONLY, 0400)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open Keystore file: %v", err)
+	}
+	defer keyStoreFile.Close()
+
+	// Read the Keystore file's JSON content.
+	keyStoreJSON, err := ioutil.ReadAll(keyStoreFile)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse Keystore file: %v", err)
+	}
+
+	// Decrypt the encrypted private key using the provided passphrase.
+	privateKey, err := keystore.DecryptKey(keyStoreJSON, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decrypt private key: %v", err)
+	}
+
+	return privateKey, nil
 }

--- a/cmd/orders_create_test.go
+++ b/cmd/orders_create_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/suite"
+)
+
+type OrdersCreateSuite struct {
+	suite.Suite
+	console      io.ReadWriter
+	url          string
+	keystoreFile string
+}
+
+func (suite *OrdersCreateSuite) SetupTest() {
+	suite.console = &bytes.Buffer{}
+	ordersCreateCmd.SetOutput(suite.console)
+	suite.url = "http://127.0.0.1:8080"
+	suite.keystoreFile = setupTestKeystoreFile(suite.Require())
+}
+
+func (suite *OrdersCreateSuite) TearDownTest() {
+	os.Remove(suite.keystoreFile)
+	ordersCreateCmd.SetOutput(nil)
+}
+
+func (suite *OrdersCreateSuite) TestOrdersCreate() {
+	for _, tt := range []struct {
+		flags        []string
+		expectedBody map[string]interface{}
+		expected     string
+	}{
+		{
+			[]string{
+				"--exchange-contract-address", "0x12459c951127e0c374ff9105dda097662a027093",
+				"--maker", "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"--taker", "0x0000000000000000000000000000000000000000",
+				"--maker-token-address", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"--taker-token-address", "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"--fee-recipient", "0xa258b39954cef5cb142fd567a46cddb31a670124",
+				"--maker-token-amount", "18981000000000000",
+				"--taker-token-amount", "19000000000000000000",
+				"--maker-fee", "0",
+				"--taker-fee", "0",
+				"--expiration-unix-timestamp-sec", "1518201120",
+				"--salt", "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"--relayer-url", suite.url,
+				"--keystore-file", suite.keystoreFile,
+				"--passphrase", "not-secure-do-not-use-me-for-anything-else",
+			},
+			map[string]interface{}{
+				"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+				"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+				"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                      "0x0000000000000000000000000000000000000000",
+				"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+				"makerTokenAmount":           "18981000000000000",
+				"takerTokenAmount":           "19000000000000000000",
+				"makerFee":                   "0",
+				"takerFee":                   "0",
+				"expirationUnixTimestampSec": "1518201120",
+				"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"ecSignature": map[string]interface{}{
+					"v": 28,
+					"r": "0x5ac1007d026a3fe62b08262fac34daa5b311e72aac81b326c028c253bfc54284",
+					"s": "0x25f08e4ba49abfd4f44205e9e01e1c552ad447747beac9b0308493b8127949c6",
+				},
+			},
+			"0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942\n",
+		},
+	} {
+		gock.New(suite.url).
+			Post("/order").
+			JSON(tt.expectedBody).
+			Reply(http.StatusCreated)
+
+		args := append(
+			[]string{"orders", "create"},
+			tt.flags...,
+		)
+		rootCmd.SetArgs(args)
+
+		suite.Require().NoError(rootCmd.Execute())
+
+		output, err := ioutil.ReadAll(suite.console)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, string(output))
+	}
+}
+
+func TestOrdersCreateSuite(t *testing.T) {
+	suite.Run(t, new(OrdersCreateSuite))
+}

--- a/cmd/orders_describe.go
+++ b/cmd/orders_describe.go
@@ -14,10 +14,6 @@ import (
 )
 
 var (
-	orderHash string
-)
-
-var (
 	ordersDescribeCmd = &cobra.Command{
 		Use: "describe",
 		Run: describeOrders,
@@ -25,8 +21,6 @@ var (
 )
 
 func init() {
-	ordersDescribeCmd.Flags().StringVar(&orderHash, "order-hash", "", "")
-
 	ordersCmd.AddCommand(ordersDescribeCmd)
 }
 

--- a/cmd/orders_describe_test.go
+++ b/cmd/orders_describe_test.go
@@ -89,9 +89,9 @@ s: 0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709
 			[]string{"orders", "describe"},
 			tt.flags...,
 		)
-
 		rootCmd.SetArgs(args)
-		rootCmd.Execute()
+
+		suite.Require().NoError(rootCmd.Execute())
 
 		output, err := ioutil.ReadAll(suite.console)
 		suite.Require().NoError(err)

--- a/cmd/orders_hash_test.go
+++ b/cmd/orders_hash_test.go
@@ -69,9 +69,9 @@ func (suite *OrdersHashSuite) TestOrdersHash() {
 			[]string{"orders", "hash"},
 			tt.flags...,
 		)
-
 		rootCmd.SetArgs(args)
-		rootCmd.Execute()
+
+		suite.Require().NoError(rootCmd.Execute())
 
 		output, err := ioutil.ReadAll(suite.console)
 		suite.Require().NoError(err)

--- a/cmd/orders_list_test.go
+++ b/cmd/orders_list_test.go
@@ -123,9 +123,9 @@ func (suite *OrdersListSuite) TestOrdersList() {
 			[]string{"orders", "list"},
 			tt.flags...,
 		)
-
 		rootCmd.SetArgs(args)
-		rootCmd.Execute()
+
+		suite.Require().NoError(rootCmd.Execute())
 
 		output, err := ioutil.ReadAll(suite.console)
 		suite.Require().NoError(err)

--- a/cmd/orders_sign_hash.go
+++ b/cmd/orders_sign_hash.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/linki/0x-go/types"
+)
+
+var (
+	ordersSignHashCmd = &cobra.Command{
+		Use: "sign-hash",
+		Run: signOrderHash,
+	}
+)
+
+func init() {
+	ordersCmd.AddCommand(ordersSignHashCmd)
+}
+
+func signOrderHash(cmd *cobra.Command, _ []string) {
+	privateKey, err := loadPrivateKey()
+	if err != nil {
+		log.Fatalf("Failed to load private key: %v", err)
+	}
+
+	signature, err := types.SignHash(common.HexToHash(orderHash), privateKey.PrivateKey)
+	if err != nil {
+		log.Fatalf("Failed to calculate the order's signature: %v", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "v: %d\nr: %s\ns: %s\n", signature.V, signature.R.Hex(), signature.S.Hex())
+}

--- a/cmd/orders_sign_hash_test.go
+++ b/cmd/orders_sign_hash_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OrdersSignHashSuite struct {
+	suite.Suite
+	console      io.ReadWriter
+	keystoreFile string
+}
+
+func (suite *OrdersSignHashSuite) SetupTest() {
+	suite.console = &bytes.Buffer{}
+	ordersSignHashCmd.SetOutput(suite.console)
+	suite.keystoreFile = setupTestKeystoreFile(suite.Require())
+}
+
+func (suite *OrdersSignHashSuite) TearDownTest() {
+	os.Remove(suite.keystoreFile)
+	ordersSignHashCmd.SetOutput(nil)
+}
+
+func (suite *OrdersSignHashSuite) TestOrdersSignHash() {
+	for _, tt := range []struct {
+		flags    []string
+		expected string
+	}{
+		{
+			[]string{
+				"--order-hash", "0x731200d7056c1a4900cb9015d208d7dd1b2424afe21baa4e74084824112c253e",
+				"--keystore-file", suite.keystoreFile,
+				"--passphrase", "not-secure-do-not-use-me-for-anything-else",
+			},
+			`v: 28
+r: 0x38c4e69b77f5e85e577337b2738fb27ddffa640a9b90971c260a4618c41bc4b2
+s: 0x12a308633603f6575bd73495d4cffd37d61ddc788b96ebe4a03b8c499a559d32
+`,
+		},
+	} {
+		args := append(
+			[]string{"orders", "sign-hash"},
+			tt.flags...,
+		)
+		rootCmd.SetArgs(args)
+
+		suite.Require().NoError(rootCmd.Execute())
+
+		output, err := ioutil.ReadAll(suite.console)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, string(output))
+	}
+}
+
+func TestOrdersSignHashSuite(t *testing.T) {
+	suite.Run(t, new(OrdersSignHashSuite))
+}

--- a/cmd/orders_test.go
+++ b/cmd/orders_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestKeystoreFile(require *require.Assertions) string {
+	someKeyStoreJSON := []byte(`{
+	  "version": 3,
+	  "id": "65c02e28-d30b-488f-aaac-877d50a9e908",
+		  "address": "d3942019eb7006d519945ff2fdd431d7c7217e89",
+	  "Crypto": {
+	    "ciphertext": "de2b750d221e5afab297ad32c29a32e10eaaacc54f23f1d62a5b50818396e618",
+	    "cipherparams": {
+	      "iv": "9386486c28d50e9c1952df22463a535f"
+	    },
+	    "cipher": "aes-128-ctr",
+	    "kdf": "scrypt",
+	    "kdfparams": {
+	      "dklen": 32,
+	      "salt": "9b1d44da48bde629f18a807032c9a1a43c404f867f0ebbb2782bcde1b7435037",
+	      "n": 8192,
+	      "r": 8,
+	      "p": 1
+	    },
+	    "mac": "638fd8f08c5a310c308e5ee08f0367756cb4fd3bb8569c9c907cb3a367b1382c"
+	  }
+	}`)
+
+	tmpfile, err := ioutil.TempFile("", "eth-test-wallet")
+	require.NoError(err)
+	defer tmpfile.Close()
+
+	_, err = tmpfile.Write(someKeyStoreJSON)
+	require.NoError(err)
+
+	return tmpfile.Name()
+}

--- a/cmd/tokens_pairs_test.go
+++ b/cmd/tokens_pairs_test.go
@@ -70,9 +70,9 @@ func (suite *TokensPairsSuite) TestTokensPairs() {
 			[]string{"tokens", "pairs"},
 			tt.flags...,
 		)
-
 		rootCmd.SetArgs(args)
-		rootCmd.Execute()
+
+		suite.Require().NoError(rootCmd.Execute())
 
 		output, err := ioutil.ReadAll(suite.console)
 		suite.Require().NoError(err)

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -181,4 +182,30 @@ func (c *Client) GetOrder(ctx context.Context, orderHash common.Hash) (types.Ord
 	}
 
 	return order, nil
+}
+
+func (c *Client) CreateOrder(ctx context.Context, order types.Order) error {
+	reqBody, err := order.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.url+"/order", bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("erroneous status code: %s", resp.Status)
+	}
+
+	return nil
 }

--- a/types/order.go
+++ b/types/order.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"time"
@@ -94,4 +95,28 @@ func (o *Order) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+func (o *Order) MarshalJSON() ([]byte, error) {
+	order := map[string]interface{}{
+		"orderHash":                  o.OrderHash,
+		"exchangeContractAddress":    o.ExchangeContractAddress,
+		"maker":                      o.Maker,
+		"taker":                      o.Taker,
+		"makerTokenAddress":          o.MakerTokenAddress,
+		"takerTokenAddress":          o.TakerTokenAddress,
+		"feeRecipient":               o.FeeRecipient,
+		"makerTokenAmount":           o.MakerTokenAmount.String(),
+		"takerTokenAmount":           o.TakerTokenAmount.String(),
+		"makerFee":                   o.MakerFee.String(),
+		"takerFee":                   o.TakerFee.String(),
+		"expirationUnixTimestampSec": fmt.Sprintf("%d", o.ExpirationUnixTimestampSec.Unix()),
+		"salt": o.Salt.String(),
+		"ecSignature": map[string]interface{}{
+			"v": o.Signature.V,
+			"r": o.Signature.R,
+			"s": o.Signature.S,
+		},
+	}
+	return json.Marshal(order)
 }

--- a/types/order_test.go
+++ b/types/order_test.go
@@ -148,6 +148,68 @@ func (suite *OrderSuite) TestUnmarshal() {
 	}
 }
 
+func (suite *OrderSuite) TestMarshal() {
+	for _, tt := range []struct {
+		orders   []Order
+		expected []map[string]interface{}
+	}{
+		{
+			[]Order{
+				{
+					OrderHash:               common.HexToHash("0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942"),
+					Maker:                   common.HexToAddress("0xc9b32e9563fe99612ce3a2695ac2a6404c111dde"),
+					Taker:                   common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					FeeRecipient:            common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+					MakerTokenAddress:       common.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+					TakerTokenAddress:       common.HexToAddress("0xe41d2489571d322189246dafa5ebde1f4699f498"),
+					ExchangeContractAddress: common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093"),
+					Salt:                       util.StrToBig("58600101225676680041453168589125977076540694791976419610199695339725548478315"),
+					MakerFee:                   common.Big0,
+					TakerFee:                   common.Big0,
+					MakerTokenAmount:           util.StrToBig("18981000000000000"),
+					TakerTokenAmount:           util.StrToBig("19000000000000000000"),
+					ExpirationUnixTimestampSec: time.Unix(1518201120, 0),
+					Signature: Signature{
+						V: 28,
+						R: common.HexToHash("0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9"),
+						S: common.HexToHash("0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709"),
+					},
+				},
+			},
+			[]map[string]interface{}{
+				{
+					"orderHash":                  "0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942",
+					"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+					"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+					"taker":                      "0x0000000000000000000000000000000000000000",
+					"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+					"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+					"feeRecipient":               "0xa258b39954cef5cb142fd567a46cddb31a670124",
+					"makerTokenAmount":           "18981000000000000",
+					"takerTokenAmount":           "19000000000000000000",
+					"makerFee":                   "0",
+					"takerFee":                   "0",
+					"expirationUnixTimestampSec": "1518201120",
+					"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+					"ecSignature": map[string]interface{}{
+						"v": 28,
+						"r": "0x2ffe986adb2ba48a800fe153ec0ec2af8b65856a34a67648e65a4bd6639c54d9",
+						"s": "0x44ea4220aec0676a41ae7d0bc2433407f2ce892217be30e39d4e44dcde127709",
+					},
+				},
+			},
+		},
+	} {
+		orders, err := json.Marshal(tt.orders)
+		suite.Require().NoError(err)
+
+		expectedJSON, err := json.Marshal(tt.expected)
+		suite.Require().NoError(err)
+
+		suite.Equal(string(expectedJSON), string(orders))
+	}
+}
+
 func TestOrderSuite(t *testing.T) {
 	suite.Run(t, new(OrderSuite))
 }

--- a/types/signature.go
+++ b/types/signature.go
@@ -1,11 +1,34 @@
 package types
 
 import (
+	"crypto/ecdsa"
+
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type Signature struct {
 	V byte
 	R common.Hash
 	S common.Hash
+}
+
+func SignHash(orderHash common.Hash, privateKey *ecdsa.PrivateKey) (Signature, error) {
+	magicMessage := crypto.Keccak256(
+		[]byte("\x19Ethereum Signed Message:\n32"),
+		orderHash.Bytes(),
+	)
+
+	sigBytes, err := crypto.Sign(magicMessage, privateKey)
+	if err != nil {
+		return Signature{}, err
+	}
+
+	signature := Signature{
+		R: common.BytesToHash(sigBytes[0:32]),
+		S: common.BytesToHash(sigBytes[32:64]),
+		V: sigBytes[64] + 27,
+	}
+
+	return signature, nil
 }

--- a/types/signature_test.go
+++ b/types/signature_test.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SignatureSuite struct {
+	suite.Suite
+}
+
+func (suite *SignatureSuite) TestSignHash() {
+	for _, tt := range []struct {
+		orderHash  string
+		privateKey string
+		expected   Signature
+	}{
+		{
+			"0x8aa8e6cbe04f63443a71fd43d511883087df205e7b47f479bc616713d13ce0c7",
+			"c325e0261d889e2cfd581be2eef17405e4a872ef7a69ada4f09e7375a08c556b",
+			Signature{
+				V: 28,
+				R: common.HexToHash("0x38ae2328af4da36d8f63b1b034e6de91f8488c4c0226754b0107b9a88532b148"),
+				S: common.HexToHash("0x7932e9f29fecd5d483bae7b07df57a04b7ca61ce6dae029274f0cc0358cc6b7c"),
+			},
+		},
+		{
+			"0x8aa8e6cbe04f63443a71fd43d511883087df205e7b47f479bc616713d13ce0c7",
+			"9df70a8bde54b8fd0121b6f28e885e85457ad81cffeea2c99ebd8c2fae863c87",
+			Signature{
+				V: 28,
+				R: common.HexToHash("0xa7be996ed9d2d754ffe235074db015647227b623cd505657924d996dbb6ba1d2"),
+				S: common.HexToHash("0x2e817c35cdb3e20bd0ffa29e8a0b6b0ede18b8b9c83b2275ce86a42841844563"),
+			},
+		},
+		{
+			"0xbbde8ab3d1e178726af9f8802380e4de79e483fff8daf29ee9b86d87e3aebf12",
+			"9df70a8bde54b8fd0121b6f28e885e85457ad81cffeea2c99ebd8c2fae863c87",
+			Signature{
+				V: 27,
+				R: common.HexToHash("0x917b943b6a2751eec7408376a07eca9b530bce2564e360377c73402bb16d797d"),
+				S: common.HexToHash("0x24fbd2428bfde0cda5614abee424525a76c52e9e46da55441e283ac09e1d535f"),
+			},
+		},
+	} {
+		orderHash := common.HexToHash(tt.orderHash)
+
+		privateKey, err := crypto.HexToECDSA(tt.privateKey)
+		suite.Require().NoError(err)
+
+		signature, err := SignHash(orderHash, privateKey)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, signature)
+	}
+}
+
+func TestSignatureSuite(t *testing.T) {
+	suite.Run(t, new(SignatureSuite))
+}


### PR DESCRIPTION
```console
$ go run main.go orders create \
  --exchange-contract-address=0x12459c951127e0c374ff9105dda097662a027093 \
  --maker=0x001eeaf1ec3c4aceaed088d1e7e151dd6dd0098c \
  --taker=0x0000000000000000000000000000000000000000 \
  --maker-token-address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
  --taker-token-address=0xe41d2489571d322189246dafa5ebde1f4699f498 \
  --fee-recipient=0xa258b39954cef5cb142fd567a46cddb31a670124 \
  --maker-token-amount=18981000000000000 \
  --taker-token-amount=19000000000000000000 \
  --maker-fee=0 \
  --taker-fee=0 \
  --expiration-unix-timestamp-sec=1518201120 \
  --salt=58600101225676680041453168589125977076540694791976419610199695339725548478324 \
  --relayer-url https://api.radarrelay.com/0x/v0 \
  --keystore-file foowallet.json \
  --passphrase "not-secure-do-not-use-me-for-anything-else"

0xbbde8ab3d1e178726af9f8802380e4de79e483fff8daf29ee9b86d87e3aebf12
```

```console
$ go run main.go orders sign-hash \
  --order-hash 0x10d750751d98bc8a9c29542118fbcf2fdb5b4977a3e5abf7cf38d03a6c149942 \
  --keystore-file foowallet.json \
  --passphrase "not-secure-do-not-use-me-for-anything-else"

v: 28
r: 0x5ac1007d026a3fe62b08262fac34daa5b311e72aac81b326c028c253bfc54284
s: 0x25f08e4ba49abfd4f44205e9e01e1c552ad447747beac9b0308493b8127949c6
```