### PR TITLE
Add option to autodetect fees on order creation

### DIFF
--- a/cmd/orders.go
+++ b/cmd/orders.go
@@ -25,8 +25,9 @@ var (
 	expirationUnixTimestampSec int64
 	salt                       string
 
-	keystoreFile string
-	passphrase   string
+	keystoreFile   string
+	passphrase     string
+	autodetectFees bool
 )
 
 var (
@@ -52,6 +53,7 @@ func init() {
 
 	ordersCmd.PersistentFlags().StringVar(&keystoreFile, "keystore-file", "", "")
 	ordersCmd.PersistentFlags().StringVar(&passphrase, "passphrase", "", "")
+	ordersCmd.PersistentFlags().BoolVar(&autodetectFees, "autodetect-fees", false, "")
 
 	rootCmd.AddCommand(ordersCmd)
 }

--- a/cmd/orders_create_test.go
+++ b/cmd/orders_create_test.go
@@ -100,6 +100,95 @@ func (suite *OrdersCreateSuite) TestOrdersCreate() {
 	}
 }
 
+func (suite *OrdersCreateSuite) TestOrdersCreateWithFeeDetection() {
+	for _, tt := range []struct {
+		expectedFeesBody map[string]string
+		feesResponse     map[string]string
+		flags            []string
+		expectedBody     map[string]interface{}
+		expected         string
+	}{
+		{
+			map[string]string{
+				"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+				"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                      "0x0000000000000000000000000000000000000000",
+				"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"makerTokenAmount":           "18981000000000000",
+				"takerTokenAmount":           "19000000000000000000",
+				"expirationUnixTimestampSec": "1518201120",
+				"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+			},
+			map[string]string{
+				"feeRecipient": "0xb046140686d052fff581f63f8136cce132e857da",
+				"makerFee":     "100000000000000",
+				"takerFee":     "200000000000000",
+			},
+			[]string{
+				"--exchange-contract-address", "0x12459c951127e0c374ff9105dda097662a027093",
+				"--maker", "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"--taker", "0x0000000000000000000000000000000000000000",
+				"--maker-token-address", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"--taker-token-address", "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"--maker-token-amount", "18981000000000000",
+				"--taker-token-amount", "19000000000000000000",
+				"--expiration-unix-timestamp-sec", "1518201120",
+				"--salt", "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"--relayer-url", suite.url,
+				"--keystore-file", suite.keystoreFile,
+				"--passphrase", "not-secure-do-not-use-me-for-anything-else",
+				"--autodetect-fees", "true",
+			},
+			map[string]interface{}{
+				"orderHash":                  "0xf52f1d9d197eb6ec0add6fcdd16ac99738c264f2f4e9ebba11c641fcda94dbf5",
+				"exchangeContractAddress":    "0x12459c951127e0c374ff9105dda097662a027093",
+				"maker":                      "0xc9b32e9563fe99612ce3a2695ac2a6404c111dde",
+				"taker":                      "0x0000000000000000000000000000000000000000",
+				"makerTokenAddress":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+				"takerTokenAddress":          "0xe41d2489571d322189246dafa5ebde1f4699f498",
+				"feeRecipient":               "0xb046140686d052fff581f63f8136cce132e857da",
+				"makerTokenAmount":           "18981000000000000",
+				"takerTokenAmount":           "19000000000000000000",
+				"makerFee":                   "100000000000000",
+				"takerFee":                   "200000000000000",
+				"expirationUnixTimestampSec": "1518201120",
+				"salt": "58600101225676680041453168589125977076540694791976419610199695339725548478315",
+				"ecSignature": map[string]interface{}{
+					"v": 28,
+					"r": "0xce571ecc4be0bbb004a9b7274b9adf07b8e1d0b473d409d6c285aace3cf2c57f",
+					"s": "0x66b2ed7465071f9a8c3ae998ea8cc816a7050931067a372fc1a1965b6a46463f",
+				},
+			},
+			"0xf52f1d9d197eb6ec0add6fcdd16ac99738c264f2f4e9ebba11c641fcda94dbf5\n",
+		},
+	} {
+		gock.New(suite.url).
+			Post("/fees").
+			JSON(tt.expectedFeesBody).
+			Reply(http.StatusOK).
+			JSON(tt.feesResponse)
+
+		gock.New(suite.url).
+			Post("/order").
+			JSON(tt.expectedBody).
+			Reply(http.StatusCreated)
+
+		args := append(
+			[]string{"orders", "create"},
+			tt.flags...,
+		)
+		rootCmd.SetArgs(args)
+
+		suite.Require().NoError(rootCmd.Execute())
+
+		output, err := ioutil.ReadAll(suite.console)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, string(output))
+	}
+}
+
 func TestOrdersCreateSuite(t *testing.T) {
 	suite.Run(t, new(OrdersCreateSuite))
 }


### PR DESCRIPTION
On order creation, when `--autodetect-fees` is provided it tries to retrieve the correct fees from the relayer's `feeinfo` endpoint.